### PR TITLE
Use HTTPS url for Pathogen git clone in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Bundle 'dockyard/vim-easydir'
 
 ```
 $ cd ~/.vim/bundle
-$ git clone git@github.com:dockyard/vim-easydir.git
+$ git clone https://github.com/dockyard/vim-easydir.git
 ```
 
 * [Vim Script](http://www.vim.org/scripts/script.php?script_id=4793)


### PR DESCRIPTION
The current Pathogen URL in README is using the SSH clone URL, which gives me a good ole error:

```
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Using the HTTPS URL allows readers of the README to clone w/o having SSH keys setup or any of that stuff.
