### PR TITLE
Generalize check for protocols in path

### DIFF
--- a/plugin/easydir.vim
+++ b/plugin/easydir.vim
@@ -1,7 +1,7 @@
 " Plugin:      easydir.vim
-" Description: A simple to create, edit and save files and directories.
-" Version:     1.1
-" Last Change: 2017 Aug 23
+" Description: A simple plugin to create, edit and save files and directories.
+" Version:     1.2
+" Last Change: 2019 Dec 22
 " Maintainer:  Doug Yun | <doug.yun@dockyard.com>
 "              DockYard, LLC 2013 | http://dockyard.com
 " License:     MIT License (MIT) | Copyright 2013
@@ -18,8 +18,7 @@ augroup END
 
 function <SID>create_and_save_directory()
   let s:directory = expand('<afile>:p:h')
-  if s:directory !~# '^\(scp\|ftp\|dav\|fetch\|ftp\|http\|rcp\|rsync\|sftp\|file\):'
-  \ && !isdirectory(s:directory)
+  if s:directory !~# '^\w\+:' && !isdirectory(s:directory)
     call mkdir(s:directory, 'p')
   endif
 endfunction

--- a/plugin/easydir.vim
+++ b/plugin/easydir.vim
@@ -17,8 +17,8 @@ augroup easydir
 augroup END
 
 function <SID>create_and_save_directory()
-  let s:directory = expand('<afile>:p:h')
-  if s:directory !~# '^\w\+:' && !isdirectory(s:directory)
-    call mkdir(s:directory, 'p')
+  let l:directory = expand('<afile>:p:h')
+  if l:directory !~# '^\w\+:' && !isdirectory(l:directory)
+    call mkdir(l:directory, 'p')
   endif
 endfunction


### PR DESCRIPTION
Listing them explicitly misses custom protocols, like "fugitive:" for example, which results in creation of meaningless directories.

I also replaced `s:` with `l:` inside `create_and_save_directory()`.